### PR TITLE
Fixed date format of mapped article to use double digit hours.

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -27,7 +27,7 @@ const methodeDateFormat = "20060102150405"
 const contentPlaceholderSourceCode = "ContentPlaceholder"
 const eomCompoundStory = "EOM::CompoundStory"
 
-const upDateFormat = "2006-01-02T03:04:05.000Z0700"
+const upDateFormat = "2006-01-02T15:04:05.000Z0700"
 const ftBrand = "http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
 const methodeAuthority = "http://api.ft.com/system/FTCOM-METHODE"
 const mapperURIBase = "http://methode-content-placeholder-mapper-iw-uk-p.svc.ft.com/content/"

--- a/mapper/test_resources/ig_placeholder_headline_only_pub_event.json
+++ b/mapper/test_resources/ig_placeholder_headline_only_pub_event.json
@@ -19,7 +19,7 @@
     },
     "alternativeImages": null,
     "alternativeStandfirsts": null,
-    "publishedDate": "2014-08-05T01:40:48.000Z",
+    "publishedDate": "2014-08-05T13:40:48.000Z",
     "publishReference": "tid_i1ktygkniy",
     "lastModified": "2016-12-16T13:13:51.154Z",
     "webUrl": "http://www.ft.com/ig/sites/2014/virgingroup-timeline/",

--- a/mapper/test_resources/ig_placeholder_pub_event.json
+++ b/mapper/test_resources/ig_placeholder_pub_event.json
@@ -24,7 +24,7 @@
     "alternativeStandfirsts": {
       "promotionalStandfirst": "Long standfirst here"
     },
-    "publishedDate": "2014-08-05T01:40:48.000Z",
+    "publishedDate": "2014-08-05T13:40:48.000Z",
     "publishReference": "tid_i1ktygkniy",
     "lastModified": "2016-12-16T13:13:51.154Z",
     "webUrl": "http://www.ft.com/ig/sites/2014/virgingroup-timeline/",


### PR DESCRIPTION
Merging this fix into the kafka topic check one to release them together.
Supersedes https://github.com/Financial-Times/methode-content-placeholder-mapper/pull/14