### PR TITLE
Mark as non-resilient, reduce severity

### DIFF
--- a/helm/methode-content-placeholder-mapper/templates/service.yaml
+++ b/helm/methode-content-placeholder-mapper/templates/service.yaml
@@ -10,6 +10,7 @@ metadata:
     app: {{.Values.service.name}}
     visualize: "true" 
     hasHealthcheck: "{{ .Values.service.hasHealthcheck }}" 
+    isResilient: "{{ .Values.service.isResilient }}"
 spec:
   ports: 
     - port: 8080 

--- a/helm/methode-content-placeholder-mapper/values.yaml
+++ b/helm/methode-content-placeholder-mapper/values.yaml
@@ -8,6 +8,7 @@ service:
   QueueReadTopic: "NativeCmsPublicationEvents"
   QueueWriteTopic: "CmsPublicationEvents"
   DocumentStoreAPIUrl: "http://document-store-api:8080"
+  isResilient: "false"
 replicaCount: 2
 image:
   repository: coco/methode-content-placeholder-mapper

--- a/resources/healthcheck.go
+++ b/resources/healthcheck.go
@@ -61,7 +61,7 @@ func (hc *MapperHealthcheck) ConsumerConnectivityCheck() fthealth.Check {
 		BusinessImpact:   "Methode content placeholders will not reach this app, nor will they be mapped to UP placeholders.",
 		Name:             "ConsumerQueueProxyReachable",
 		PanicGuide:       "https://dewey.ft.com/up-mcpm.html",
-		Severity:         1,
+		Severity:         2,
 		TechnicalSummary: "Consumer message queue proxy is not reachable/healthy",
 		Checker:          hc.consumer.ConnectivityCheck,
 	}
@@ -73,7 +73,7 @@ func (hc *MapperHealthcheck) ProducerConnectivityCheck() fthealth.Check {
 		BusinessImpact:   "Methode content placeholders mappings will not be publish",
 		Name:             "ProducerQueueProxyReachable",
 		PanicGuide:       "https://dewey.ft.com/up-mcpm.html",
-		Severity:         1,
+		Severity:         2,
 		TechnicalSummary: "Producer message queue proxy is not reachable/healthy",
 		Checker:          hc.producer.ConnectivityCheck,
 	}
@@ -84,7 +84,7 @@ func (hc *MapperHealthcheck) DocumentStoreConnectivityCheck() fthealth.Check {
 		BusinessImpact:   "Internal content placeholders will not publish",
 		Name:             "DocumentStoreApiReachable",
 		PanicGuide:       "https://dewey.ft.com/up-mcpm.html",
-		Severity:         1,
+		Severity:         2,
 		TechnicalSummary: "document-store-api is not reachable/healthy",
 		Checker:          hc.docStore.ConnectivityCheck,
 	}

--- a/resources/healthcheck_test.go
+++ b/resources/healthcheck_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const defaultSeverity = uint8(2)
+
 func setupMockKafka(t *testing.T, status int) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(status)
@@ -57,21 +59,21 @@ func TestHealthchecks(t *testing.T) {
 	assert.Equal(t, "ConsumerQueueProxyReachable", consumerCheck.Name)
 	assert.True(t, consumerCheck.Ok)
 	assert.True(t, consumerCheck.PanicGuide != "")
-	assert.Equal(t, uint8(1), consumerCheck.Severity)
+	assert.Equal(t, defaultSeverity, consumerCheck.Severity)
 
 	producerCheck := result.Checks[1]
 	assert.True(t, producerCheck.BusinessImpact != "")
 	assert.Equal(t, "ProducerQueueProxyReachable", producerCheck.Name)
 	assert.True(t, producerCheck.Ok)
 	assert.True(t, producerCheck.PanicGuide != "")
-	assert.Equal(t, uint8(1), producerCheck.Severity)
+	assert.Equal(t, defaultSeverity, producerCheck.Severity)
 
 	docStoreCheck := result.Checks[2]
 	assert.True(t, docStoreCheck.BusinessImpact != "")
 	assert.Equal(t, "DocumentStoreApiReachable", docStoreCheck.Name)
 	assert.True(t, docStoreCheck.Ok)
 	assert.True(t, docStoreCheck.PanicGuide != "")
-	assert.Equal(t, uint8(1), docStoreCheck.Severity)
+	assert.Equal(t, defaultSeverity, docStoreCheck.Severity)
 }
 
 func TestFailingKafka(t *testing.T) {


### PR DESCRIPTION
- mappers aren't resilient: both pods read from kafka using the same consumer group - this means only one of them is actually receiving the messages; if the pod which isn't receiving the messages stops, that's not problem, but if the pod who is actually receiving the messages stops working, then the other pod will not pick up messages either
- by marking it as non-resilient, the upp-aggregate-healthcheck (any versions which include this [PR](https://github.com/Financial-Times/upp-aggregate-healthcheck/pull/22)) will report the highest severity of any failed pods as the severity for the service 
- reduced the severity from 1 to 2 so any failures in this service will not turn dashing red